### PR TITLE
First Name Only

### DIFF
--- a/core/components/personalize/elements/snippets/snippet.personalize.php
+++ b/core/components/personalize/elements/snippets/snippet.personalize.php
@@ -38,6 +38,9 @@
  *
  *    @property fullName boolean (optional) Use full name
  *        instead of username in placeholder
+ *  
+ *    @property firstName boolean (optional) Show only the
+ *        first part of the fullname. (i.e. Bob Ray == Bob)
  *
  *    @property ifIds string (optional) comma separated 
  *        list of users ids; yesChunk will only be shown
@@ -90,6 +93,7 @@ $sp =& $scriptProperties;
 $yesChunk = $modx->getOption('yesChunk',$sp, null);
 $noChunk = $modx->getOption('noChunk',$scriptProperties, null);
 $fullName = $modx->getOption('fullName', $sp, null);
+$firstName = $modx->getOption('firstName',$scriptProperties, 0);
 $ph = $modx->getOption('ph',$sp, null);
 $ifIds = $modx->getOption('ifIds',$sp, null);
 
@@ -107,7 +111,11 @@ if ($modx->user->hasSessionContext($modx->context->get('key')) && ( $ifIds == fa
     }
     if (! empty($ph)) {
         if ($fullName && $profile) {
-            $modx->setPlaceholder($ph, $profile->get('fullname'));
+            $thename = $profile->get('fullname');
+			if ($firstName) {
+				$thename = (strstr($thename, ' ') ? strstr($thename, ' ',true) : $thename);
+			}
+			$modx->setPlaceholder($ph, $thename);
         } else {
             $modx->setPlaceholder($ph, $modx->user->get('username'));
         }


### PR DESCRIPTION
This commit would allow for you to return the first name only instead of the entire "fullname" field for instances that you feel "Welcome back Bob!" looks nicer than "Welcome back Bob Ray!". I tried to accomplish this with output filters and snippets, but neither seemed to work so I had to embed this directly into the snippet code.

Here it is in case you think others might find value in this..
